### PR TITLE
Minor bug fixes on Android

### DIFF
--- a/src/android/FirebaseInvites.java
+++ b/src/android/FirebaseInvites.java
@@ -110,7 +110,7 @@ public class FirebaseInvites extends CordovaPlugin implements GoogleApiClient.On
               }
 
               if (options.has("callToActionText")) {
-                builder.setCallToActionText(options.getString("deepLink"));
+                builder.setCallToActionText(options.getString("callToActionText"));
               }
 
               if (options.has("customImage")) {
@@ -154,7 +154,7 @@ public class FirebaseInvites extends CordovaPlugin implements GoogleApiClient.On
         try {
           JSONObject response = new JSONObject()
               .put("count", ids.length)
-              .put("invitationIds", ids);
+              .put("invitationIds", new JSONArray(ids));
           _sendInvitationCallbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, response));
         } catch (JSONException e) {
           _sendInvitationCallbackContext.error(e.getMessage());


### PR DESCRIPTION
BTW for simplicity I'd recommend in the `sendInvitation` method return just array of `invitationIds`. You can determine number of invites by checking `length` field of that array.

Also noticed a typo on http://plugins.telerik.com/cordova/plugin/firebase-invites:
`ASSOCIATED_DOMAIN` -> `ASSOCIATED_DOMAINS`
